### PR TITLE
rfc: syncing figma to code

### DIFF
--- a/rfcs/0001.syncing-figma-to-code.md
+++ b/rfcs/0001.syncing-figma-to-code.md
@@ -1,0 +1,115 @@
+# Syncing Figma to Code
+
+## Authors
+
+Travis Arnold, @souporserious
+
+## Deadline
+
+Tuesday, May 17th, 2022
+
+## Introduction
+
+There is currently no standardized way to sync changes from Figma to our codebase. This lack of synchronization results in assets spread across many areas, making it cumbersome to analyze and update.
+
+This RFC aims to gain feedback on adding a formal process for automating gathering assets from Figma and turning them into published package[s] on NPM.
+
+---
+
+## Motivation
+
+Keeping assets in sync is hard across most codebases. The process usually goes like this:
+
+A designer creates a new icon and publishes it to a Figma design system.
+A stakeholder adds or updates the icon in the respective codebase to the latest version.
+Add a PR for review. If it is not accepted, repeat steps 1 and 2. (For example, it looks bad in situ and needs tweaks).
+Publish the library for consumption in other applications.
+Update application that initially required the icon.
+
+Right now, we do not have the problem of needing to publish an additional library for icons since they are currently only used in `devtools`. However, to better manage this process, I propose we either move to a monorepo structure to separate the `devtools` build from this icon build or start publishing design-specific packages under the `design` repository.
+
+---
+
+## Guiding Principles
+
+To help prioritize goals, these are the guiding principles:
+
+1. **Synchronized source of truth**
+
+All sources from Figma and our codebase should eventually be fully in sync. For example, sources like colors, icons, and illustrations are synced _from_ Figma, and components, pages, and flows are synced _to_ Figma.
+
+2. **Optimize Contributions**
+
+Contributing and editing icons should be as easy as possible. This feedback loop is essential when prototyping and trying ideas in real-world situations. For example, a server immediately syncs any design changes from Figma to the codebase and rebuilds the icon set.
+
+---
+
+## Proposed Changes
+
+To avoid disruptions, we should progressively use this new technique. There's no need to modify the existing code unless necessary.
+
+### Auto publishing packages
+
+Set up [Changesets](https://github.com/changesets/changesets) to help automate the publishing of multiple packages using the icons package as a starting point.
+
+### GitHub Action
+
+Add a GitHub Action that utilizes [figma webhooks](https://souporserious.com/getting-started-with-figma-webhooks/) and the [figma-tools](https://github.com/figma-tools/figma-tools) package to pull in our icons and keep them in sync.
+
+- The Action should auto-update the PR with changes using a mechanism like calling the workflow explicitly from a Figma plugin.
+- Alternatively, if we can use the Figma design system published event from a webhook, this would be ideal as it does not require bidirectional authentication.
+
+### Icon Component
+
+The `Icon` component will be responsible for rendering icons. It takes the following props:
+
+#### size: union from theme sizes
+
+The size prop controls both the width and height of the `svg` element and is based on a theme value like `small`, `medium`, `large`.
+
+#### name: generated union from icon build
+
+The name prop accepts a string that autocompletes with the available icons from the set.
+
+```tsx
+<Icon name="trash" />
+```
+
+While this format is excellent for autocompletion in TypeScript and keeping a simple interface, it does not allow for tree-shaking unused icons, which can bloat the final build. Build size is most critical when thinking about `Icon` used in a marketing page and is something we can solve with a build script that injects a component source in place of a string like below, giving us great DX _and_ optimized builds for users.
+
+#### source: React.ReactNode
+
+The source prop accepts an icon component source from the build step to render:
+
+```tsx
+import { Icon } from '@replayio/components'
+import { TrashIcon } from '@replayio/icons'
+
+export function Example() {
+  return <Icon source={TrashIcon} size="small" />
+}
+```
+
+This prop should never be needed, and opting for the `name` prop plus build step will be the most straightforward and performant path to getting icons on the screen.
+
+#### fill: union from theme colors
+
+The color of the overall icon.
+
+---
+
+## Other Considerations
+
+### Complicating the build
+
+While this will help automate our synchronization with Figma, it does introduce complexity into our build system for getting these icons into code. Once initially set up, it should require low maintenance.
+
+### Assets beyond icons
+
+The initial implementation is scoped and will only deal with icon synchronization. Additional assets will be considered after the initial implementation is complete.
+
+---
+
+## Conclusion
+
+With these tools in place, we can start to formalize our process for design to contribute to our codebase. In the end, we can prototype more quickly and try out ideas in situ as fast as possible.


### PR DESCRIPTION
[This RFC](https://github.com/RecordReplay/design/blob/rfcs/rfcs/0001.syncing-figma-to-code.md) proposes a system for synchronizing our icons to this repository using the Figma API.

## Deadline

Tuesday, May 17th, 2022